### PR TITLE
Feature: Add a contact us link in the footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ baseurl: '/website'
 google_analytics_key:
 google_maps_javascript_api_key:
 disqus_shortname:
+support_mail: "support@bioontology.org"
 
 # Values for the jekyll-seo-tag gem (https://github.com/jekyll/jekyll-seo-tag)
 logo: /siteicon.png

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -3,8 +3,6 @@
     link: /blog/
   - name: About
     link: /about/
-  - name: Contact
-    link: /contact/
 - links:
   - name: Docs
     link: /

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,10 +10,6 @@
   link: /blog/
   new_window: false
   highlight: false
-- name: Contact
-  link: /contact/
-  new_window: false
-  highlight: false
 - name: documentation
   link: https://ontoportal.github.io/documentation/
   new_window: true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,6 +42,7 @@
 								{% endif %}
 								{{ link.name }}</a></li>
 						{% endfor %}
+						<li><a href="mailto:{{site.support_mail}}">Contact us</a></li>
 					</ul>
 					{% endfor %}
 				</div>


### PR DESCRIPTION
Add a "contact us" link in the footer, which opens a new email with the configured support mail (in the _config.yml file)