### PR TITLE
Feature: Add link to demo server

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@
 
 title: OntoPortal
 url: "https://ontoportal.org/"
+virtual_appliance_url: "https://ontoportal.github.io/documentation/administration/steps/getting_started"
+demo_url: "https://demo.ontoportal.org"
 baseurl: '/website'
 google_analytics_key:
 google_maps_javascript_api_key:
@@ -114,7 +116,7 @@ sponsors:
     link: https://www.enit.fr/fr/index.html
     portals: 'IndustryPortal'
   - acronym: 'BMICC'
-    logo: '/images/sponsor_logos/Bmicc.png'
+    logo: '/website/images/sponsor_logos/Bmicc.png'
     link: http://www.bmicc.cn/web/share/home/
     portals: 'MedPortal'
 

--- a/index.html
+++ b/index.html
@@ -7,12 +7,20 @@ description: Ontology Repositories or Semantic Artefact Catalogues with the Onto
 	<div class="text-container">
 		<h1 class="editable"><strong>OntoPortal</strong>, a generic technology to build ontology repositories or semantic artefact catalogues</h1>
 		<p class="subtext editable">The most advanced and rich technology for ontology services!</p>
-		<div class="cta button alt"><a href="https://ontoportal.github.io/documentation/administration/steps/getting_started">Get your own OntoPortal</a></div>
+		<div class="cta button alt">
+			<a href="{{ site.virtual_appliance_url }}">Get your own OntoPortal</a>
+
+		</div>
+		<div class="cta button alt">
+			<a href="{{ site.demo_url }}">See a demo of OntoPortal</a>
+		</div>
+
 		<div>
 			<img src="{{ site.baseurl }}/images/OntoPortalInstances_v3.png" alt="Screenshot" class="screenshot editable" />
 		</div>
-			<p class="subtext editable">Teams in the <strong>OntoPortal Alliance</strong> develop and maintain several openly accessible ontology repositories including BioPortal, the primary and historical source of OntoPortal code, but also AgroPortal, EcoPortal, MatPortal and more...</p>
-		<div class="cta button alt"><a href="https://demoportal.ontoportal.org">Get a demo of OntoPortal</a></div>
+
+		<p class="subtext editable">Teams in the <strong>OntoPortal Alliance</strong> develop and maintain several openly accessible ontology repositories including BioPortal, the primary and historical source of OntoPortal code, but also AgroPortal, EcoPortal, MatPortal and more...</p>
+
 	</div>
 </section>
 


### PR DESCRIPTION
### Changes 

- add demo_url and virtual_appliance_url config variables(https://github.com/ontoportal/website/commit/cb33fabb34645a51dea702b5cc42de59c2519fe6)
- add demo button link to ontoportal demo(https://github.com/ontoportal/website/commit/e54e0cd74e76185a2e89c3005359b599e5b00191)

<img width="798" alt="image" src="https://github.com/ontoportal/website/assets/29259906/c316fb4c-f0c5-4cf3-ab1c-80540395b768">
