### PR TITLE
Fix: Some logos (Bmicc and Industryportal)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -116,7 +116,7 @@ sponsors:
     link: https://www.enit.fr/fr/index.html
     portals: 'IndustryPortal'
   - acronym: 'BMICC'
-    logo: '/website/images/sponsor_logos/Bmicc.png'
+    logo: '/images/sponsor_logos/Bmicc.png'
     link: http://www.bmicc.cn/web/share/home/
     portals: 'MedPortal'
 

--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,7 @@ alliance_members:
     link: http://industryportal.enit.fr
     description: "A common ontology portal for industry and related domains"
     logo: '/images/alliance_member_logos/industryportal.png'
-    color: '#74a9cb'
+    color: '#1c0f5d'
   
 
 sponsors:


### PR DESCRIPTION
### Changes 

- Fix industry portal logo color(https://github.com/ontoportal/website/commit/0868f69ab9f5ac7f1ae546b4703cefdda6eb7aa3)
![image](https://github.com/ontoportal/website/assets/29259906/978f463d-02bc-4324-a777-3e73e5bf8e0c)

- Fix the Bmicc sponsor logo (https://github.com/ontoportal/website/commit/73785d77f45b7eead901de8ba6dd43bd9b1346be)
![image](https://github.com/ontoportal/website/assets/29259906/6ef19841-e055-4f44-91d7-396b1ac9ba2d)
