### PR TITLE
Add blog posts for workshops (2020–2026) and ISWC publications

### DIFF
--- a/_posts/2020-05-18-ontoportal-alliance-kickoff-meeting.md
+++ b/_posts/2020-05-18-ontoportal-alliance-kickoff-meeting.md
@@ -1,0 +1,22 @@
+---
+title: OntoPortal Alliance Kickoff Meeting
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2020-05-18
+ - 
+---
+
+The OntoPortal Alliance held its **inaugural online kickoff meeting** from May 18-20, 2020, bringing together the founding teams for three days of presentations, technical discussions, and strategic planning.
+
+Participants included representatives from **Stanford BMIR** (Mark Musen, John Graybeal, Jennifer Vendetti, Michael Dorf, Alex Skrenchuk), **LIRMM** (Clement Jonquet and team), **LifeWatch** (Nicola Fiore and team), **BMICC** (Xiaolin Yang and team), and guest company **Cogni.zone** (Agis Papantoniou, Thomas Grivegnée).
+
+The three-day agenda covered:
+- **Day 1 – Work Status**: Presentations from each team on deployed portals (AgroPortal, SIFR, MedPortal, EcoPortal) and BioPortal, plus an update on the OntoPortal virtual appliance (releases 2.4, 2.5, 3.0).
+- **Day 2 – Technical**: Discussion of technical needs and a roadmap for new features including ontology metadata models, mapping repositories, multilingual annotators, SKOS handling, and internationalization.
+- **Day 3 – Strategic**: Mission statement, governance framework, funding strategies, and social presence of the Alliance.
+
+Key features already in development at the time included: AllegroGraph backend (BioPortal), advanced metadata (AgroPortal), Annotator+ (SIFR/AgroPortal), FAIRness assessment (AgroPortal), DOI assignment (EcoPortal), and SKOS support (EcoPortal).
+
+This meeting established the shared foundation for the OntoPortal Alliance's open-source collaborative model, which has grown continuously since.

--- a/_posts/2022-10-10-ontoportal-workshop-2022-report.md
+++ b/_posts/2022-10-10-ontoportal-workshop-2022-report.md
@@ -1,0 +1,24 @@
+---
+title: OntoPortal Workshop 2022 Report
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2022-10-10
+ - 
+---
+
+The **1st OntoPortal Workshop** took place at LIRMM, Montpellier, France, from September 26-29, 2022. Around 20 participants gathered, including management, research, and technical profiles from the Alliance teams.
+
+The 2022 workshop's main goals were to consolidate the OntoPortal Alliance organization and shared agenda, and to engage the broader scientific community. The program included technical, content, and management sessions, as well as a **public session** attended by 35 participants, which featured a general presentation of OntoPortal, a user panel, and a technical tutorial on setting up an OntoPortal appliance.
+
+Key highlights and discussions:
+- **Portal updates**: Teams from BioPortal, AgroPortal, EcoPortal, MatPortal, IndustryPortal, Cogni.zone, and NFDI4Biodiversity presented their status and roadmaps.
+- **Shared GitHub**: Commitment to centralize the OntoPortal open-source code on [github.com/ontoportal](https://github.com/ontoportal) to enable collaborative contributions via pull requests.
+- **Feature roadmap**: Priority topics identified included metadata models, mappings, federated access, multilingualism, and DevOps/infrastructure.
+- **OntoPortal philosophy**: Agreed that new features should be modular, domain-agnostic, and activatable via configuration — making the technology applicable to the widest range of use cases.
+- **New portals**: NFDI4Biodiversity confirmed plans to adopt OntoPortal for their next-generation terminology service.
+
+This first workshop established the annual meeting as a cornerstone of the Alliance's collaborative model, a tradition continued each year since.
+
+The full report is available on HAL: [hal-04087929](https://hal.science/hal-04087929).

--- a/_posts/2023-10-10-ontoportal-workshop-2023-report.md
+++ b/_posts/2023-10-10-ontoportal-workshop-2023-report.md
@@ -1,0 +1,25 @@
+---
+title: OntoPortal Workshop 2023 Report
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2023-10-10
+ - 
+---
+
+The **2nd OntoPortal Workshop** took place in Lecce, Italy from September 26-29, 2023, hosted by the LifeWatch team. Around 30 participants (25 on site, 5 online) gathered to consolidate the Alliance's organization and shared agenda, and to engage the broader scientific community.
+
+The program included technical, content, and management sessions, as well as public events: a virtual session on the Ontology Development Lifecycle and the [FAIR-IMPACT Semantic Artefact Governance Workshop](https://fair-impact.eu). Topics discussed included multilingualism, federated services, ontology versioning, mappings, documentation, and general Alliance governance.
+
+Key highlights from the workshop:
+- Publication of a **reference paper at ISWC 2023** introducing OntoPortal as a generic tool for building ontology repositories and semantic artefact catalogues.
+- Release of the **new OntoPortal website** at [ontoportal.org](https://ontoportal.org).
+- Shared **documentation portal** at [ontoportal.org/documentation](https://ontoportal.org/documentation).
+- Progress on **Docker packaging** and virtual appliance (v3.2.0).
+- Renewed commitment to the shared upstream code on GitHub at [github.com/ontoportal](https://github.com/ontoportal).
+- First steps toward **federated services** across multiple OntoPortal-based repositories.
+
+The full report is available on HAL: [hal-04494573](https://hal.science/hal-04494573).
+
+The next workshop will be held in 2024. Stay tuned for announcements!

--- a/_posts/2023-11-07-ontoportal-paper-iswc-2023.md
+++ b/_posts/2023-11-07-ontoportal-paper-iswc-2023.md
@@ -1,0 +1,21 @@
+---
+title: OntoPortal Technology Paper Published at ISWC 2023
+categories:
+ - Publications
+ - News
+author_staff_member: Clement Jonquet
+date: 2023-11-07
+ - 
+---
+
+We are delighted to announce the publication of our reference paper on the OntoPortal technology at the **22nd International Semantic Web Conference (ISWC 2023)** in Athens, Greece.
+
+**"Ontology Repositories and Semantic Artefact Catalogues with the OntoPortal Technology"**  
+Clement Jonquet, John Graybeal, Syphax Bouazzouni, Michael Dorf, Nicola Fiore, Xeni Kechagioglou, Timothy Redmond, Ilaria Rosati, Alex Skrenchuk, Jennifer L. Vendetti, Mark Musen, and members of the OntoPortal Alliance.
+
+The paper presents OntoPortal as a generic platform for building ontology repositories and semantic artefact catalogues. It reviews the features of OntoPortal—from browsing, search, annotation, and recommendation services to FAIRness assessment, metadata management, and API access—and showcases the current and forthcoming public repositories built with the technology and maintained by the Alliance.
+
+**Please use this paper to cite and reference OntoPortal and the Alliance's work.**
+
+- Full text (open access): [hal.science/hal-04088537](https://hal.science/hal-04088537)
+- DOI: [10.1007/978-3-031-47243-5_3](https://dx.doi.org/10.1007/978-3-031-47243-5_3)

--- a/_posts/2024-06-01-ontoportal-workshop-2024-announced.md
+++ b/_posts/2024-06-01-ontoportal-workshop-2024-announced.md
@@ -1,0 +1,24 @@
+---
+title: OntoPortal Workshop 2024 Announced
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2024-06-01
+ - 
+---
+
+We are pleased to announce the **3rd OntoPortal Alliance Workshop**, to be held at Stanford University (BMIR), USA, from **September 23-26, 2024**.
+
+The 2024 workshop's main goals are to consolidate the OntoPortal Alliance organization and shared agenda, and to engage with newcomers interested in adopting the OntoPortal technology. The program will include technical, content, and management sessions, as well as a newcomers session featuring new use cases from the astronomy, cultural heritage, and vocabulary communities.
+
+Topics on the agenda include:
+- OntoPortal year in review and team updates
+- Federated services (first joint release of Agro/Eco/Earth/BiodivPortal)
+- New interfaces and features (URI management, SPARQL query capabilities, LLM-enhanced Annotator)
+- Virtual appliance and DevOps
+- Alliance governance and sustainability
+
+The event is primarily restricted to Alliance members and invited guests. For more information or to express interest in participating, please contact:
+- Clement Jonquet (INRAE/U.Montpellier) — jonquet@lirmm.fr
+- John Graybeal (Stanford University) — jgraybeal@stanford.edu

--- a/_posts/2024-10-15-ontoportal-workshop-2024-report.md
+++ b/_posts/2024-10-15-ontoportal-workshop-2024-report.md
@@ -1,0 +1,23 @@
+---
+title: OntoPortal Workshop 2024 Report
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2024-10-15
+ - 
+---
+
+The **3rd OntoPortal Workshop** took place at Stanford University (BMIR), USA, from September 23-26, 2024. Around 20 participants (13 on site, 7 online) gathered to advance collaboration and engage with newcomers.
+
+The workshop re-aligned the Alliance on questions related to the management of the upstream OntoPortal code repository and the distribution of the virtual appliance. Key highlights included:
+
+- **Federated services**: Demonstration of the first federation of four OntoPortal-based repositories (AgroPortal, EcoPortal, EarthPortal, BiodivPortal) with a joint release in preparation.
+- **New interfaces and features**: URI management, embedded SPARQL query editor, new search capabilities.
+- **AI prototypes**: Revised Annotator using LLMs and a BioPortal-based CustomGPT prototype.
+- **New public portals**: Arrival of OntoPortal-Astro (astronomy, Observatoire de Paris) and TechnoPortal ([technoportal.hevs.ch](https://technoportal.hevs.ch), technology sciences, OST/HES-SO).
+- **Shared documentation** now available at [ontoportal.org/documentation](https://ontoportal.org/documentation).
+
+The Alliance renewed its commitment to open source development on the shared GitHub repository at [github.com/ontoportal](https://github.com/ontoportal), while acknowledging the need to improve contribution workflows between the main development teams.
+
+The full report is available on HAL: [hal-04891214](https://hal.science/hal-04891214).

--- a/_posts/2025-06-01-ontoportal-workshop-2025-announced.md
+++ b/_posts/2025-06-01-ontoportal-workshop-2025-announced.md
@@ -1,0 +1,26 @@
+---
+title: OntoPortal Workshop 2025 Announced
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2025-06-01
+ - 
+---
+
+We are pleased to announce the **4th OntoPortal Alliance Workshop**, to be held at the **Freie Universität Berlin – Institute of Computer Science**, Germany, from **September 29 to October 3, 2025**.
+
+The 2025 workshop's main goals are to consolidate the Alliance's organization and shared agenda, and to engage with newcomers. The program will include technical, content, and management sessions, as well as a newcomers session featuring new use cases in social science, heritage science, cultural heritage, and astronomy.
+
+Topics on the agenda include:
+- Overview of OntoPortal, the OntoPortal Federation, and the MOD-API
+- Integration opportunities with TS4NFDI and NFDI consortia
+- Federation strategies and governance
+- New use cases and onboarding of emerging instances
+- AI integration (OntoPortal MCP and RAG prototypes)
+- Metadata practices, SKOS/OntoLex support, and duplicate management
+- Virtual Appliance planning and developer coordination
+
+The event is primarily restricted to Alliance members and invited guests. For more information or to express interest in participating, please contact:
+- Clement Jonquet (INRAE/U.Montpellier) — clement.jonquet@inrae.fr
+- Naouel Karam (InfAI, Leipzig) — karam@infai.org

--- a/_posts/2025-11-05-ontoportal-federation-paper-iswc-2025.md
+++ b/_posts/2025-11-05-ontoportal-federation-paper-iswc-2025.md
@@ -1,0 +1,21 @@
+---
+title: OntoPortal Federation Paper Published at ISWC 2025
+categories:
+ - Publications
+ - News
+author_staff_member: Clement Jonquet
+date: 2025-11-05
+ - 
+---
+
+We are pleased to announce the publication of a new paper on the OntoPortal Federation at the **24th International Semantic Web Conference (ISWC 2025)** in Nara, Japan.
+
+**"Federated FAIR Semantic Artefacts Discovery and Search with OntoPortal Federation"**  
+Clement Jonquet, Syphax Bouazzouni, Guillaume Alviset, Nicola Fiore, Naouel Karam, Bilel Kihal, Christelle Pierkot, Martina Pulieri, Ilaria Rosati.
+
+The paper presents the OntoPortal Federation, a technical and collaboration framework enabling multiple OntoPortal-based semantic artefact catalogues to interoperate. It showcases how **AgroPortal, EcoPortal, EarthPortal, and BiodivPortal** have been federated to support seamless browsing and search across their respective disciplines—agri-food, ecology, earth sciences, and biodiversity.
+
+The paper defines semantic artefact catalogue interoperability, reports on three complementary approaches studied in the context of the FAIR-IMPACT project, and details the architecture and governance decisions behind the federation. It also discusses technical challenges and future directions toward a sustainable, community-driven semantic layer for open science data infrastructures.
+
+- Full text (open access): [hal.science/hal-05224287](https://hal.science/hal-05224287)
+- DOI: [10.1007/978-3-032-09530-5_25](https://doi.org/10.1007/978-3-032-09530-5_25)

--- a/_posts/2026-05-26-ontoportal-workshop-2025-report.md
+++ b/_posts/2026-05-26-ontoportal-workshop-2025-report.md
@@ -1,0 +1,26 @@
+---
+title: OntoPortal Workshop 2025 Report
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2026-05-26
+ - 
+---
+
+The **4th OntoPortal Workshop** took place at the Freie Universität Berlin – Institute of Computer Science, Germany, from September 29 to October 3, 2025. Around 20 participants gathered, joined by online contributors and guests from the NFDI community.
+
+The workshop opened with presentations on OntoPortal, the OntoPortal Federation, and the MOD-API, followed by a live feature demonstration. The event also featured presentations from TS4NFDI highlighting integration of OntoPortal within NFDI consortia (NFDI4Biodiversity, FAIRagro, NFDI4Earth, DataPlant, MatWerk), comparisons with TIB's Terminology Service, and a session on COCODA for mapping tool integration.
+
+Key highlights included:
+
+- **Strong and growing community**: a dozen new persons in the Alliance and four new OntoPortal instances in social sciences, heritage science, cultural heritage, and astronomy.
+- **AI integration**: presentation of an OntoPortal MCP prototype and an OntoPortal RAG prototype, exploring how generative AI can enhance OntoPortal services.
+- **Federation governance**: review of the federation memorandum of understanding, onboarding procedures, and future directions toward a more formal organizational structure.
+- **New publications**: including the [ISWC 2025 Federation paper](https://hal.science/hal-05224287), a BioPortal NAR article, and several portal-specific papers.
+- **Zenodo community** created for OntoPortal-related outputs, alongside a collaborative [Zotero bibliographic collection](https://www.zotero.org/groups/6228656/ontoportal_alliance_biblio) gathering around 70 items.
+- **Virtual Appliance**: planning for the next VA release and coordination of upstream code contributions.
+
+The workshop reinforced the shared vision of interoperable and FAIR semantic artefact infrastructures and outlined next steps for the Alliance.
+
+The full report is available on HAL: [hal-05633274](https://hal.inrae.fr/hal-05633274v1).

--- a/_posts/2026-06-23-ontoportal-workshop-2026-announced.md
+++ b/_posts/2026-06-23-ontoportal-workshop-2026-announced.md
@@ -1,0 +1,16 @@
+---
+title: OntoPortal Workshop 2026 Announced
+categories:
+ - Happenings
+ - News
+author_staff_member: Clement Jonquet
+date: 2026-06-23
+ - 
+---
+
+We are pleased to announce the **5th OntoPortal Alliance Workshop**, to be held in **Paris, France, from September 21-25, 2026**, hosted by the [Observatoire de Paris](https://www.obspm.fr) (OntoPortal-Astro team).
+
+As with previous editions, the workshop will gather Alliance members and invited guests for several days of technical, content, and management sessions. More details on the program and public sessions will be announced in the coming months.
+
+For more information or to express interest in participating, please contact:
+- Clement Jonquet (INRAE/U.Montpellier) — clement.jonquet@inrae.fr


### PR DESCRIPTION
## Summary

- Add 10 blog posts to fill the gap since the last post (Sept 2023)
- **Kickoff meeting** May 2020 (founding of the Alliance)
- **Workshop 2022 report** (Montpellier) — links to HAL hal-04087929
- **Workshop 2023 report** (Lecce) — links to HAL hal-04494573
- **ISWC 2023 paper** announcement — DOI 10.1007/978-3-031-47243-5_3, HAL hal-04088537
- **Workshop 2024 announcement + report** (Stanford) — links to HAL hal-04891214
- **Workshop 2025 announcement + report** (Berlin) — links to HAL hal-05633274
- **ISWC 2025 Federation paper** announcement — DOI 10.1007/978-3-032-09530-5_25, HAL hal-05224287
- **Workshop 2026 announcement** (Paris, Observatoire de Paris)

Introduces a new `Publications` category for paper announcement posts.

## Test plan
- [x] Build passes locally (`bundle exec jekyll serve`)
- [x] Blog page lists all posts in correct chronological order
- [x] All HAL and DOI links are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)