### PR TITLE
Fix typos in features section

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,12 +172,12 @@ description: Ontology Repositories or Semantic Artefact Catalogues with the Onto
 				<li>
 					<div class="service-circle square-image">New user interfaces</div>
 					<div class="name"></div>
-					<div class="position">Easy-to-use modern and respnsive user interfaces.</div>
+					<div class="position">Easy-to-use modern and responsive user interfaces.</div>
 				</li>
 				<li>
 					<div class="service-circle square-image">URIs dereferencing</div>
 					<div class="name"></div>
-					<div class="position">Easy-to-use infratructure supporting ontology URI dereferencing (resolutuon and content negociation).</div>
+					<div class="position">Easy-to-use infrastructure supporting ontology URI dereferencing (resolution and content negotiation).</div>
 				</li>
 				<li>
 					<div class="service-circle square-image">Agents profiling</div>
@@ -187,7 +187,7 @@ description: Ontology Repositories or Semantic Artefact Catalogues with the Onto
 				<li>
 					<div class="service-circle square-image">Related projects</div>
 					<div class="name"></div>
-					<div class="position">Rewamped ontology related project functionalities inclduing connectors to funded project databases.</div>
+					<div class="position">Revamped ontology related project functionalities including connectors to funded project databases.</div>
 				</li>
 				<li>
 					<div class="service-circle square-image">MOD-API support</div>
@@ -202,7 +202,7 @@ description: Ontology Repositories or Semantic Artefact Catalogues with the Onto
 				<li>
 					<div class="service-circle square-image">Change requests</div>
 					<div class="name"></div>
-					<div class="position">Suggest ontology content changes (new terms, synonyms, definitions) direclty from OntoPortal to GitHub.</div>
+					<div class="position">Suggest ontology content changes (new terms, synonyms, definitions) directly from OntoPortal to GitHub.</div>
 				</li>
 				<li>
 					<div class="service-circle square-image">Authentication & SSO</div>


### PR DESCRIPTION
## Summary

Fixes 4 typos in the features section of the homepage:
- `respnsive` → `responsive`
- `infratructure` → `infrastructure`
- `resolutuon` → `resolution`
- `negociation` → `negotiation`
- `inclduing` → `including`
- `Rewamped` → `Revamped`
- `direclty` → `directly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)