### PR TITLE
Add retired/coming badges and placeholders for upcoming portals

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ alliance_members:
     description: "A repository for French biomedical terminologies and ontologies"
     logo: '/images/alliance_member_logos/sifr_bioportal.png'
     color: '#74a9cb'
+    retired: true
   - name: 'AgroPortal'
     link: https://agroportal.lirmm.fr/
     description: "A vocabulary and ontology repository for agronomy and related domains"
@@ -64,6 +65,7 @@ alliance_members:
     description: "A common ontology portal for industry and related domains"
     logo: '/images/alliance_member_logos/industryportal.png'
     color: '#1c0f5d'
+    retired: true
   - name: 'EarthPortal'
     link: https://earthportal.eu/
     description: "A semantic artefact repository dedicated to Earth sciences"
@@ -84,7 +86,19 @@ alliance_members:
     description: "A vocabulary and ontology repository for astronomy and related domains"
     logo: '/images/alliance_member_logos/ontoportal-astro.png'
     color: '#624ECF'
-    
+  - name: 'LovPortal'
+    description: "A gateway to reusable semantic vocabularies on the Web"
+    coming: true
+  - name: 'HSPortal'
+    description: "The home of ontologies and semantic artefacts in Heritage Science."
+    coming: true
+  - name: 'CHPortal'
+    description: "ECHOES repository of Cultural Heritage ontologies"
+    coming: true
+  - name: 'SocioPortal'
+    description: "CESSDA repository of social sciences ontologies and semantic artefacts"
+    coming: true
+
 sponsors:
   - acronym: 'D2KAB'
     logo: https://agroportal.lirmm.fr/assets/logos/collaboration/d2kab_logo-5155645cfcfe00890f3cad2307ca7975a1ff43b841755002830c99aba060a9e5.png

--- a/index.html
+++ b/index.html
@@ -273,11 +273,49 @@ description: Ontology Repositories or Semantic Artefact Catalogues with the Onto
 				<h2>Be part of a <strong>community</strong></h2>
 			</div>
 
+			<style>
+				.portal-badge {
+					display: inline-block;
+					font-size: 0.68em;
+					font-weight: 600;
+					letter-spacing: 0.04em;
+					text-transform: uppercase;
+					padding: 2px 7px;
+					border-radius: 4px;
+					vertical-align: middle;
+					margin-left: 5px;
+				}
+				.portal-badge-retired { background: #f3dede; color: #a33; }
+				.portal-badge-coming  { background: #ddeeff; color: #1a6aaa; }
+				.portal-coming-box {
+					height: 100px;
+					background-color: #d8d8d8;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					width: 200px;
+					border-radius: 200px;
+					margin: 25px auto 0px;
+				}
+				.portal-coming-box span {
+					color: #888;
+					font-size: 0.85em;
+					font-style: italic;
+				}
+			</style>
 			<ul class="staff">
 				{% for portal in site.alliance_members %}
 				<li>
+					{% if portal.coming %}
+					<div class="portal-coming-box"><span>coming soon</span></div>
+					<div class="name">{{ portal.name }} <span class="portal-badge portal-badge-coming">coming</span></div>
+					{% elsif portal.retired %}
+					<div style="height: 100px;background-color:{{portal.color}}" class="square-image"><img src="{% include relative-src.html src=portal.logo %}" alt="{{ portal.name }}" style="object-fit: contain;width: 200px; height: 100px; opacity: 0.7;"/></div>
+					<div class="name"><a target="_blank" href="{{ portal.link }}" style="color: black">{{ portal.name }}</a> <span class="portal-badge portal-badge-retired">retired</span></div>
+					{% else %}
 					<div style="height: 100px;background-color:{{portal.color}}" class="square-image"><img src="{% include relative-src.html src=portal.logo %}" alt="{{ portal.name }}" style="object-fit: contain;width: 200px; height: 100px"/></div>
 					<div class="name"><a target="_blank" href="{{ portal.link }}" style="color: black">{{ portal.name }}</a></div>
+					{% endif %}
 					<div class="position">{{ portal.description }}</div>
 				</li>
 				{% endfor %}


### PR DESCRIPTION
## Summary

- Adds a **RETIRED** badge (red) on SIFR BioPortal and IndustryPortal, with reduced opacity on their logo
- Adds 4 new **coming soon** portal placeholders: LovPortal, HSPortal, CHPortal, SocioPortal — each displayed as a gray ellipse (matching existing portal shape) with a **COMING** badge (blue)
- Portal data (`_config.yml`) uses new `retired: true` / `coming: true` flags; the Liquid template in `index.html` handles the rendering conditionally

## Test plan

- [x] Verify SIFR BioPortal and IndustryPortal show the RETIRED badge
- [x] Verify 4 new portals appear with gray ellipse and COMING badge
- [x] Verify existing portals are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)